### PR TITLE
Do not check process on browser environments

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -4,8 +4,7 @@ import { PublicKey } from "@solana/web3.js";
  * false if in a Node process
  */
 export const isBrowser =
-  process.env.SHDW_BROWSER ||
-  (typeof window !== "undefined" && !window.process?.hasOwnProperty("type"));
+  (typeof window !== "undefined" && !window.process?.hasOwnProperty("type")) || process.env.SHDW_BROWSER;
 
 export const programAddress = new PublicKey(
   "2e1wdyNhUvE76y6yUCvah2KaviavMJYKoRun8acMRBZZ"


### PR DESCRIPTION
In browser environments `process` is not defined, so the library may break.

By adding the `process.env` check at the end of the statement we can get around this issue.