### PR TITLE
Add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,16 @@ cd shadow-drive
 yarn install
 ```
 
+### Troubleshooting
+
+#### Getting a 400 HTTP error code when performing POST requests
+
+If you are getting a 400 HTTP error status code when using the POST `ShdwDrive` methods such as `createStorageAccount`, `uploadFile`, `addStorage`, etc.
+
+Make sure to set your wallet adapter <code>commitment</code> config to <code>max</code>.
+
+```TSX
+<ConnectionProvider endpoint={network} config={{ commitment: 'max' }}>
+  ...
+</ConnectionProvider>
+```


### PR DESCRIPTION
There's a 400 error happening when performing http POST requests methods from the `ShdwDrive` such as `createStorageAccount`.

By setting the `{{ commitment: 'max' }}` config in the wallet adapter these issues should be gone.