### PR TITLE
Set react as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^18.0.9",
     "jest": "^28.1.0",
     "jest-config": "^28.1.0",
+    "react": "^18.1.0",
     "ts-jest": "^28.0.2",
     "ts-jest-resolver": "^2.0.0",
     "typedoc": "^0.22.15",
@@ -40,7 +41,9 @@
     "@solana/spl-token": "^0.2.0",
     "@solana/wallet-adapter-react": "^0.15.4",
     "cross-fetch": "^3.1.5",
-    "form-data": "^4.0.0",
-    "react": "^18.1.0"
+    "form-data": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18"
   }
 }


### PR DESCRIPTION
This sets `react` as a `peerDependency` instead of a `dependency` to resolve issues around duplicates or mismatching versions of `react` installed in projects using the `@shadow-drive/sdk` library.

See https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react