### PR TITLE
extend ShadowBatchUploadResponse with tx sig, use type

### DIFF
--- a/src/methods/upload-multiple-files.ts
+++ b/src/methods/upload-multiple-files.ts
@@ -34,7 +34,7 @@ export default async function uploadMultipleFiles(
   const selectedAccount = await this.program.account.storageAccount.fetch(key);
   let fileData: Array<FileData> = [];
   const fileErrors: Array<object> = [];
-  let existingUploadJSON = [];
+  let existingUploadJSON: ShadowBatchUploadResponse[] = [];
   /**
    *
    * Prepare files for uploading.
@@ -363,6 +363,7 @@ export default async function uploadMultipleFiles(
               fileName: name,
               status: "Uploaded.",
               location: actualFiles[idx].url,
+              transaction_signature: responseJson.transaction_signature
             });
           });
           continueToNextBatch = true;

--- a/src/methods/upload-multiple-files.ts
+++ b/src/methods/upload-multiple-files.ts
@@ -348,6 +348,7 @@ export default async function uploadMultipleFiles(
                 fileName: name,
                 status: `Not uploaded: ${error}`,
                 location: null,
+                transaction_signature: null
               });
             });
             continueToNextBatch = true;
@@ -374,6 +375,7 @@ export default async function uploadMultipleFiles(
             fileName: name,
             status: `Not uploaded: ${e}`,
             location: null,
+            transaction_signature: null
           });
         });
         continueToNextBatch = true;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,9 @@ export type ShadowBatchUploadResponse = {
   fileName: string;
   status: string;
   location: string;
+  transaction_signature?: string;
 };
+
 export type StorageAccountResponse = {
   publicKey: anchor.web3.PublicKey;
   account: StorageAccount;


### PR DESCRIPTION
- extends ShadowBatchUploadResponse type to pass tx signatures along
- this will result in duplicate tx signatures as we are batching up to 5 files but I think that is ok here