### PR TITLE
Add math.ceil for bytes

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -115,7 +115,7 @@ export function humanSizeToBytes(input: string): number | boolean {
       break;
   }
 
-  return inputNumber * chunk_size;
+  return Math.ceil(inputNumber * chunk_size);
 }
 
 export function bytesToHuman(bytes: any, si = false, dp = 1) {


### PR DESCRIPTION
Resolves https://github.com/GenesysGo/shadow-drive-cli/issues/7 by adding `Math.ceil` when calculating bytes from a human-readable string.