### PR TITLE
Add version type to storage account info response

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,7 @@ export type ShadowUploadResponse = {
   message: string;
   upload_errors: Array<UploadError>;
 };
+
 export type UploadError = {
   file: string;
   storage_account: string;
@@ -44,7 +45,7 @@ export type StorageAccountInfo = {
   current_usage: number;
   immutable: boolean;
   to_be_deleted: boolean;
-  delet_request_epoch: number;
+  delete_request_epoch: number;
   owner1: PublicKey;
   account_counter_seed: number;
   creation_time: number;
@@ -53,6 +54,7 @@ export type StorageAccountInfo = {
   identifier: string;
   version: `${Uppercase<ShadowDriveVersion>}`;
 };
+
 export type StorageAccount = {
   isStatic: boolean;
   initCounter: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export type StorageAccountInfo = {
   creation_epoch: number;
   last_fee_epoch: number;
   identifier: string;
+  version: `${Uppercase<ShadowDriveVersion>}`;
 };
 export type StorageAccount = {
   isStatic: boolean;


### PR DESCRIPTION
This adds the `version` property to the `StorageAccountInfo` type, which is missing.

It can be either `V1` or `V2`.

<img width="149" alt="CleanShot 2022-10-01 at 22 12 26@2x" src="https://user-images.githubusercontent.com/3136873/193436554-f2596f39-93d9-4112-b2eb-fe8f5fb4fa93.png">

It would be a good idea to return it as lowercase from the server to have the version as uniform as possible throughout the codebase and to avoid comparison issues, but for now this type works at least to detect and be aware of the expected response.

<img width="407" alt="CleanShot 2022-10-01 at 22 11 45@2x" src="https://user-images.githubusercontent.com/3136873/193436626-81254d09-bd4a-4159-b876-1d44da313eb1.png">

This also fixes an incorrect property name, `delet_request_epoch` to `delete_request_epoch` 👍
