### PR TITLE
Decode url in file delete method

### DIFF
--- a/src/methods/delete-file.ts
+++ b/src/methods/delete-file.ts
@@ -32,7 +32,7 @@ export default async function deleteFile(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      location: url,
+      location: decodeURI(url),
     }),
   });
   const fileDataResponse = await fileData.json();


### PR DESCRIPTION
There's a current issue when trying to delete files with spaces in the filename.

By decoding the url in the file deletion method, the API call succeeds when there are files with spaces in their filename.

Here's a demo showing the failure:

https://user-images.githubusercontent.com/3136873/193437379-d54fb730-33aa-416c-b282-5cca1f5db122.mp4

Here's one with the fix in place:

https://user-images.githubusercontent.com/3136873/193437391-13fa8fdb-9d80-4752-85cc-5684c4ab78f6.mp4

