### PR TITLE
Add correct edit response type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
   ShadowDriveResponse,
   ShadowFile,
   ShadowUploadResponse,
+  ShadowEditResponse,
   StorageAccount,
   StorageAccountResponse,
   ListObjectsResponse,
@@ -63,7 +64,7 @@ interface ShadowDrive {
     url: string,
     data: File | ShadowFile,
     version: ShadowDriveVersion
-  ): Promise<ShadowUploadResponse>;
+  ): Promise<ShadowEditResponse>;
   getStorageAcc?(key: web3.PublicKey): Promise<StorageAccount>;
   getStorageAccs?(): Promise<StorageAccount[]>;
   listObjects(key: web3.PublicKey): Promise<ListObjectsResponse>;
@@ -165,6 +166,7 @@ export {
   CreateStorageResponse,
   ShadowDriveResponse,
   ShadowUploadResponse,
+  ShadowEditResponse,
   ShadowFile,
   StorageAccount,
   StorageAccountResponse,

--- a/src/methods/edit-file.ts
+++ b/src/methods/edit-file.ts
@@ -1,7 +1,7 @@
 import * as anchor from "@project-serum/anchor";
 import { isBrowser, SHDW_DRIVE_ENDPOINT } from "../utils/common";
 import crypto from "crypto";
-import { ShadowDriveVersion, ShadowFile, ShadowUploadResponse } from "../types";
+import { ShadowDriveVersion, ShadowFile, ShadowEditResponse } from "../types";
 import fetch from "cross-fetch";
 import NodeFormData from "form-data";
 import { bs58 } from "@project-serum/anchor/dist/cjs/utils/bytes";
@@ -12,7 +12,7 @@ import nacl from "tweetnacl";
  * @param {string} url - URL of existing file
  * @param {File | ShadowFile} data - File or ShadowFile object, file extensions should be included in the name property of ShadowFiles.
  * @param {ShadowDriveVersion} version - ShadowDrive version (v1 or v2)
- * @returns {ShadowUploadResponse} - File location and transaction signature
+ * @returns {ShadowEditResponse} - File location
  */
 
 export default async function editFile(
@@ -20,7 +20,7 @@ export default async function editFile(
   url: string,
   data: File | ShadowFile,
   version: ShadowDriveVersion
-): Promise<ShadowUploadResponse> {
+): Promise<ShadowEditResponse> {
   let fileErrors = [];
   let fileBuffer: Buffer | ArrayBuffer;
   let form;
@@ -119,7 +119,7 @@ export default async function editFile(
 				  Server response status message: ${(await uploadResponse.json()).error}`)
       );
     }
-    const responseJson = await uploadResponse.json();
+    const responseJson: ShadowEditResponse = await uploadResponse.json();
     return Promise.resolve(responseJson);
   } catch (e) {
     return Promise.reject(new Error(e));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,11 @@ export type ShadowUploadResponse = {
   message: string;
   upload_errors: Array<UploadError>;
 };
+
+export type ShadowEditResponse = {
+  finalized_location: string;
+};
+
 export type UploadError = {
   file: string;
   storage_account: string;

--- a/tests/shadow-drive.spec.ts
+++ b/tests/shadow-drive.spec.ts
@@ -6,6 +6,7 @@ import {
   ShadowDriveResponse,
   ShadowFile,
   ShadowUploadResponse,
+  ShadowEditResponse,
   ShdwDrive,
   StorageAccountInfo,
 } from "../src";
@@ -98,7 +99,7 @@ describe("shadow-drive v2 sdk testing", () => {
       file,
       "v2"
     );
-    expect.objectContaining<ShadowUploadResponse>(editRes);
+    expect.objectContaining<ShadowEditResponse>(editRes);
   });
   it("deletes file on shadow drive", async () => {
     const delRes = await drive.deleteFile(
@@ -229,7 +230,7 @@ describe("shadow-drive v1 sdk testing", () => {
       file,
       "v1"
     );
-    expect.objectContaining<ShadowUploadResponse>(editRes);
+    expect.objectContaining<ShadowEditResponse>(editRes);
   });
   //   it("retrieves all file-accounts for a v1 storage account", async () => {
   //     const fileAccounts = await drive.getFileAccounts(


### PR DESCRIPTION
When uploading a file, the response comes as the following type:

```
finalized_locations: Array<string>;
message: string;
upload_errors: Array<UploadError>;
```

When editing an already existing file, the response comes as: `{ finalized_location: string }`

This PR adds the correct type so that clients knows what will they receive in each response.

