### PR TITLE
In getStorageAccounts(), convert this.wallet.pubKey to base58 string

### DIFF
--- a/src/methods/get-storage-accounts.ts
+++ b/src/methods/get-storage-accounts.ts
@@ -12,12 +12,14 @@ export default async function getStorageAccs(
 ): Promise<StorageAccountResponse[]> {
   let storageAccounts;
   try {
+    const walletPubKey = this.wallet.publicKey?.toBase58() ?? this.wallet.publicKey;
+    
     switch (version.toLocaleLowerCase()) {
       case "v1":
         storageAccounts = await this.program.account.storageAccount.all([
           {
             memcmp: {
-              bytes: this.wallet.publicKey,
+              bytes: walletPubKey,
               offset: 39,
             },
           },
@@ -27,7 +29,7 @@ export default async function getStorageAccs(
         storageAccounts = await this.program.account.storageAccountV2.all([
           {
             memcmp: {
-              bytes: this.wallet.publicKey,
+              bytes: walletPubKey,
               offset: 22,
             },
           },


### PR DESCRIPTION
… this function isn't working because it's not passing an expected base58 string to the memcmp.bytes property.