### PR TITLE
Updates for new commitment status

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,75 +20,57 @@ yarn add @shadow-drive/sdk
 ```
 
 ### Setup (React)
+
 ```tsx
 import React, { useEffect } from "react";
 import * as anchor from "@project-serum/anchor";
-import {ShdwDrive} from "@shadow-drive/sdk";
-import { AnchorWallet, useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
+import { ShdwDrive } from "@shadow-drive/sdk";
+import {
+    AnchorWallet,
+    useAnchorWallet,
+    useConnection,
+} from "@solana/wallet-adapter-react";
 
 export default function Drive() {
-	const { connection } = useConnection();
-	const wallet = useAnchorWallet();
-	useEffect(() => {
-		(async () => {
-			if (wallet?.publicKey) {
-				const drive = await new ShdwDrive(connection, wallet).init();
-			}
-		})();
-	}, [wallet?.publicKey])
-	return (
-		<div></div>
-	)
+    const { connection } = useConnection();
+    const wallet = useAnchorWallet();
+    useEffect(() => {
+        (async () => {
+            if (wallet?.publicKey) {
+                const drive = await new ShdwDrive(connection, wallet).init();
+            }
+        })();
+    }, [wallet?.publicKey]);
+    return <div></div>;
 }
 ```
 
 ### Setup (NodeJS)
-```js
-import {ShdwDrive} from "@shadow-drive/sdk";
-const drive = await new ShdwDrive(connection, wallet).init();
 
+```js
+import { ShdwDrive } from "@shadow-drive/sdk";
+import * as web3 from "@solana/web3.js";
+const connection = new web3.Connection("{rpc-url}", "processed");
+const drive = await new ShdwDrive(connection, wallet).init();
 ```
 
 ### Examples
 
-| package                                                                                                               | description                                                                |
-| --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| package                                                                   | description                                       |
+| ------------------------------------------------------------------------- | ------------------------------------------------- |
 | [react](https://github.com/GenesysGo/shadow-drive/tree/main/examples/web) | Using shadow-drive in a react/browser environment |
 
 ### Build From Source
+
 1. Clone the project:
+
 ```shell
 git clone https://github.com/genesysgo/shadow-drive.git
 ```
 
 2. Install dependencies:
+
 ```shell
 cd shadow-drive
 yarn install
-```
-
-### Troubleshooting
-
-#### Getting a 400 HTTP error code when performing POST requests
-
-If you are getting a 400 HTTP error status code when using the POST `ShdwDrive` methods such as `createStorageAccount`, `uploadFile`, `addStorage`, etc.
-
-Make sure to set your wallet adapter or connection <code>commitment</code> config to <code>max</code>.
-
-```TSX
-<ConnectionProvider endpoint={network} config={{ commitment: 'max' }}>
-  ...
-</ConnectionProvider>
-```
-
-```JS
-const connection = new solanaWeb3.Connection(
-    "https://{region}.genesysgo.net/{YOUR_ACCOUNT_UUID_HERE}",
-	{
-		commitment: "max", 
-		httpHeaders: {
-			Authorization:
-			"Bearer {GENESYSGO AUTHENTICATION TOKEN HERE}",
-		}
-	});
 ```

--- a/examples/web/src/App.tsx
+++ b/examples/web/src/App.tsx
@@ -32,7 +32,7 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
 
 	return (
 		<ConnectionProvider endpoint={network} config={{
-			commitment: 'max', httpHeaders: {
+			commitment: 'processed', httpHeaders: {
 				Authorization:
 					"Bearer {GENESYSGO AUTHENTICATION TOKEN HERE}",
 			}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -152,7 +152,7 @@ export const awaitTransactionSignatureConfirmation = async (
   txid: anchor.web3.TransactionSignature,
   timeout: number,
   connection: anchor.web3.Connection,
-  commitment: anchor.web3.Commitment = "recent",
+  commitment: anchor.web3.Commitment = "processed",
   queryStatus = false
 ): Promise<anchor.web3.SignatureStatus | null | void> => {
   let done = false;


### PR DESCRIPTION
- Prepares new docs updates that removes the requirement of `max` commitment status for the connection
- Updates examples to set commitment status to `processed`
- Sets commitment status to `processed` by default in helpers

This update should wait to be merged until the shadow network upgrade is performed.